### PR TITLE
add_Parrafo1: se agrega el primer párrafo de la noticia

### DIFF
--- a/Noticia.html
+++ b/Noticia.html
@@ -18,12 +18,21 @@
             </ul>
         </nav>
     </header>
-    <h1>Diego Schwartzman perdió un partido increíble <br> ante Stefanos Tsitsipas por el Masters 1000 de <br> Montecarlo</h1>
-    <h2 style="font-size: medium;">El argentino estuvo 6-2 y 5-2 abajo y luego, 4-0 arriba en el tercer set, pero cayó por 6-2, 6-7 y 6-4 <br> ante el número 5 del mundo luego de 2 horas y 43 minutos</h2>
+    <h1 style="font-family: Arial, Helvetica, sans-serif;">Diego Schwartzman perdió un partido increíble <br> ante Stefanos Tsitsipas por el Masters 1000 de <br> Montecarlo</h1>
+    <p style="font-size: large; font-family: Arial, Helvetica, sans-serif;">El argentino estuvo 6-2 y 5-2 abajo y luego, 4-0 arriba en el tercer set, pero cayó por 6-2, 6-7 y 6-4 <br> ante el número 5 del mundo luego de 2 horas y 43 minutos</p>
+    <p style="font-family: Verdana, Geneva, Tahoma, sans-serif;">15 de abril de 2022 * 20:07</p>
     <div>
         <img src="https://resizer.glanacion.com/resizer/eumR9sgUgOjr_MDGdJb4tnhcNbw=/80x0/filters:format(webp):quality(80)/s3.amazonaws.com/arc-authors/lanacionar/2707801.png" alt="Carlos Delfino"><p style="color: blue; font: bold;">Carlos Delfino</p><br><p style="color: gray;">LA NACION</p>
         <img src="https://resizer.glanacion.com/resizer/tiOVjFn6iLs86QNNhTeZXGYi45o=/1200x746/smart/filters:format(webp):quality(80)/cloudfront-us-east-1.images.arcpublishing.com/lanacionar/3ZGUT3LRIVGZJADUVBTECQHYCI.JPG" alt="Diego Schwartzman">
+        <p style="font-family: Arial, Helvetica, sans-serif;">Diego Schwartzman perdió con Stefanos Tsitsipas por los cuartos de final del Masters 1000 de Montecarlo</p>
+        <p style="color: gray;">VALERY HACHE - AFP</p>
+        <p>----------------------------------------------------------------------------------------------------------------------------------------------------------</p>
+        <p style="font-family: Arial, Helvetica, sans-serif; font-size: large;"><b style="font-size: xx-large;">S</b>e le escapó. Se le escurrió un éxito que por momentos parecía muy lejano y luego <br>estaba increíblemente a su alcance. <b>Diego Schwartzman</b>, 16º en la <br>clasificación mundial, tuvo contra las cuerdas a <b>Stefanos Tsitsipas</b>, campeón <br>defensor, tercer favorito del torneo y 5 en el ranking ATP, pero dejó pasar la <br>oportunidad. Por los cuartos de final del <b>Masters 1000 de Montecarlo</b>, el tercer <br>torneo de esa categoría de la temporada, el Peque cayó por 6-2, 6-7 (3-7) y 6-4, en un <br>partido en el que la mejor reacción fue la del griego, que llegó a estar 0-4 en el parcial <br>definitivo.
+           Sobre polvo de ladrillo, <b>Tsitsipas se puso pronto en ventaja por 5-0</b>, tras quebrar <br>los dos primeros servicios del argentino aprovechando dos de los cuatro puntos de <br>quiebre con los que contó. Sólido y agresivo en su juego, no lo dejó pensar ni reaccionar <br>al Peque. En apenas 24 minutos ya tenía una diferencia abrumadora a su favor al caer <br>la noche en el Principado de Mónaco.</p>
     </div>
+    <section>
+
+    </section>
     
 </body>
 </html>


### PR DESCRIPTION
Se agregó la fecha de edición de la noticia sobre la imagen del periodista.  Fue agregada también la descripción de la imagen del tenista y supongo que es el nombre de la fotógrafa.
Agregué una separación de guiones (simulando la que aparece originalmente) y el primer párrafo de la noticia, con una letra inicial destacada y las palabras del texto resaltadas en negrita según aparecen.